### PR TITLE
Fixed documentation of numerical cmp

### DIFF
--- a/check_generic
+++ b/check_generic
@@ -237,7 +237,7 @@ Options:
    (can be a complete filter chain)
 -u|w|c|o, --unknown,warning,critical,ok <expression>
    operator is perl operators, e.g.
-      '= n'	- numerically equal
+      '== n'	- numerically equal
       '< n'	- numerically equal
       '> n'	- numerically equal
       'eq s'	- string equal


### PR DESCRIPTION
Hi Matthias,

Der numerische Vergleich mit = klappt nicht:
check_generic -e "wget -q http://localhost -O - | grep -c welcome" -w '= 1' -c '= 2' -o '== 0'

do_analysis: eval was _not_ successful rc:0 severity:warning expression:>1= 1<

Mit == klappts, daher nehme ich an, dass die Doku da ein = vergessen hat.

Grüße,
 Sven
